### PR TITLE
Fix feeding log schema bug

### DIFF
--- a/app/schemas/feeding_log.py
+++ b/app/schemas/feeding_log.py
@@ -6,7 +6,7 @@ class FeedingLogBase(BaseModel):
     start_time: datetime
     end_time: datetime
     food_type: Optional[str] = None
-    amount: Optional[int] = None
+    amount: Optional[str] = None
     notes: Optional[str] = None
 
 class FeedingLogCreate(FeedingLogBase):


### PR DESCRIPTION
## Summary
- fix type mismatch for `amount` in feeding log schema

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687bd9db8d888325808b14115573a800